### PR TITLE
Enable PowerTools repo for snappy-devel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM centos:latest
 
 # Install Dependencies 
 RUN yum -y install epel-release
+RUN yum -y install yum-uils && yum-config-manager --enable PowerTools
 RUN yum install -y tcpdump sudo libaio-devel leveldb-devel snappy-devel libcap-devel libseccomp-devel \
     gcc-c++ make git golang jq which openssl
 


### PR DESCRIPTION
PowerTools repo that contains snappy-devel is disabled by default.

Install yum-utils for enabling the PowerTools repo